### PR TITLE
add endpoints for users, desks, bookings

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -14,6 +14,6 @@ api.use("/v1/desks", deskRouter);
 
 api.use("/v1/bookings", bookingRouter);
 
-api.use("/v1/users", userRouter);
+api.use("/v1/auth", userRouter);
 
 export default api;

--- a/api/api.js
+++ b/api/api.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 // import messageRouter from "./messages/messageRouter.js";
 
+import bookingRouter from "./modules/bookings/bookingRouter.js";
 import deskRouter from "./modules/desks/deskRouter.js";
 import userRouter from "./modules/users/userRouter.js";
 
@@ -10,6 +11,8 @@ const api = Router();
 // api.use("/message", messageRouter);
 
 api.use("/v1/desks", deskRouter);
+
+api.use("/v1/bookings", bookingRouter);
 
 api.use("/v1/users", userRouter);
 

--- a/api/api.js
+++ b/api/api.js
@@ -1,9 +1,13 @@
 import { Router } from "express";
 
-import messageRouter from "./messages/messageRouter.js";
+// import messageRouter from "./messages/messageRouter.js";
+
+import deskRouter from "./modules/desks/deskRouter.js";
 
 const api = Router();
 
-api.use("/message", messageRouter);
+// api.use("/message", messageRouter);
+
+api.use("/v1/desks", deskRouter);
 
 export default api;

--- a/api/api.js
+++ b/api/api.js
@@ -3,11 +3,14 @@ import { Router } from "express";
 // import messageRouter from "./messages/messageRouter.js";
 
 import deskRouter from "./modules/desks/deskRouter.js";
+import userRouter from "./modules/users/userRouter.js";
 
 const api = Router();
 
 // api.use("/message", messageRouter);
 
 api.use("/v1/desks", deskRouter);
+
+api.use("/v1/users", userRouter);
 
 export default api;

--- a/api/fixtures/bookings.js
+++ b/api/fixtures/bookings.js
@@ -1,0 +1,9 @@
+export let bookings = [
+	{
+		booking_id: 123,
+		desk_id: "abc",
+		user_id: 2,
+		from_date: "2025-07-05T13:00:00",
+		to_date: "2025-07-05T19:00:00",
+	},
+];

--- a/api/fixtures/desks.js
+++ b/api/fixtures/desks.js
@@ -1,0 +1,4 @@
+export const desks = [
+	{ id: "abc", name: "Desk 1" },
+	{ id: "def", name: "Desk 2" },
+];

--- a/api/fixtures/users.js
+++ b/api/fixtures/users.js
@@ -1,0 +1,4 @@
+export const users = [
+	{ id: 1, firstName: "Lucas", lastName: "Smith" },
+	{ id: 2, firstName: "Edlahdj", lastName: "Jones" },
+];

--- a/api/messages/messageRepository.js
+++ b/api/messages/messageRepository.js
@@ -1,6 +1,6 @@
-import db from "../db.js";
+/* import db from "../db.js";
 
 export async function getAll() {
 	const { rows } = await db.query("SELECT * FROM message;");
 	return rows;
-}
+} */

--- a/api/messages/messageRouter.js
+++ b/api/messages/messageRouter.js
@@ -1,4 +1,4 @@
-import { Router } from "express";
+/* import { Router } from "express";
 
 import { getMessage } from "./messageService.js";
 
@@ -8,4 +8,4 @@ router.get("/", async (_, res) => {
 	res.send(await getMessage());
 });
 
-export default router;
+export default router; */

--- a/api/messages/messageService.js
+++ b/api/messages/messageService.js
@@ -1,6 +1,6 @@
-import * as repository from "./messageRepository.js";
+/* import * as repository from "./messageRepository.js";
 
 export async function getMessage() {
 	const [first] = await repository.getAll();
 	return first.content;
-}
+} */

--- a/api/modules/bookings/bookingRepository.js
+++ b/api/modules/bookings/bookingRepository.js
@@ -1,0 +1,29 @@
+import { bookings } from "../../fixtures/bookings.js";
+
+export function getBookingsForDate(date) {
+	return bookings.filter((b) => b.from_date.startsWith(date));
+}
+
+export function isDeskBookedOnDate(desk_id, date) {
+	return getBookingsForDate(date).some((b) => b.desk_id === desk_id);
+}
+
+export function isUserBookedOnDate(user_id, date) {
+	return getBookingsForDate(date).some((b) => b.user_id === user_id);
+}
+
+export function createBooking({ user_id, desk_id, date }) {
+	const from_date = new Date(date + "T13:00:00").toISOString();
+	const to_date = new Date(date + "T19:00:00").toISOString();
+
+	const booking = {
+		booking_id: Math.floor(Math.random() * 1000000),
+		user_id,
+		desk_id,
+		from_date,
+		to_date,
+	};
+
+	bookings.push(booking);
+	return booking;
+}

--- a/api/modules/bookings/bookingRouter.js
+++ b/api/modules/bookings/bookingRouter.js
@@ -1,0 +1,19 @@
+import { Router } from "express";
+
+import { handleCreateBooking } from "./bookingService.js";
+
+const router = Router();
+
+// Not RESTful - should be POST /api/v1/bookings - might consider changing it
+router.post("/create_booking", (req, res) => {
+	const { user_id, desk_id } = req.body;
+
+	if (!user_id || !desk_id) {
+		return res.status(400).json({ error: "Missing user_id or desk_id" });
+	}
+
+	const booking = handleCreateBooking({ user_id, desk_id });
+	res.status(201).json(booking);
+});
+
+export default router;

--- a/api/modules/bookings/bookingService.js
+++ b/api/modules/bookings/bookingService.js
@@ -1,0 +1,19 @@
+import {
+	isUserBookedOnDate,
+	isDeskBookedOnDate,
+	createBooking,
+} from "./bookingRepository.js";
+
+export function handleCreateBooking({ user_id, desk_id, date }) {
+	const bookingDate = date
+		? new Date(date).toISOString().slice(0, 10)
+		: new Date().toISOString().slice(0, 10);
+
+	if (isUserBookedOnDate(user_id, bookingDate)) {
+		throw new Error("User already has a booking for this date.");
+	}
+	if (isDeskBookedOnDate(desk_id, bookingDate)) {
+		throw new Error("Desk is already booked for this date.");
+	}
+	return createBooking({ user_id, desk_id, date: bookingDate });
+}

--- a/api/modules/desks/deskRouter.js
+++ b/api/modules/desks/deskRouter.js
@@ -1,0 +1,11 @@
+import { Router } from "express";
+
+import { getDesks } from "./deskService.js";
+
+const router = Router();
+
+router.get("/", async (_, res) => {
+	res.send(await getDesks());
+});
+
+export default router;

--- a/api/modules/desks/deskRouter.js
+++ b/api/modules/desks/deskRouter.js
@@ -4,8 +4,8 @@ import { getDesks } from "./deskService.js";
 
 const router = Router();
 
-router.get("/", async (_, res) => {
-	res.send(await getDesks());
+router.get("/", (_, res) => {
+	res.send(getDesks());
 });
 
 export default router;

--- a/api/modules/desks/deskService.js
+++ b/api/modules/desks/deskService.js
@@ -1,5 +1,5 @@
 import * as repository from "./desksRepository.js";
 
-export async function getDesks() {
+export function getDesks() {
 	return repository.getAll();
 }

--- a/api/modules/desks/deskService.js
+++ b/api/modules/desks/deskService.js
@@ -1,0 +1,5 @@
+import * as repository from "./desksRepository.js";
+
+export async function getDesks() {
+	return repository.getAll();
+}

--- a/api/modules/desks/desksRepository.js
+++ b/api/modules/desks/desksRepository.js
@@ -1,0 +1,5 @@
+import { desks } from "../../fixtures/desks.js";
+
+export function getAll() {
+	return desks;
+}

--- a/api/modules/users/userRepository.js
+++ b/api/modules/users/userRepository.js
@@ -1,0 +1,12 @@
+import { users } from "../../fixtures/users.js";
+
+export function createUser({ firstName, lastName }) {
+	const user = {
+		id: Math.floor(Math.random() * 1000000),
+		firstName: firstName,
+		lastName: lastName,
+	};
+
+	users.push(user);
+	return user;
+}

--- a/api/modules/users/userRepository.js
+++ b/api/modules/users/userRepository.js
@@ -1,6 +1,6 @@
 import { users } from "../../fixtures/users.js";
 
-export function createUser({ firstName, lastName }) {
+export function registerUser({ firstName, lastName }) {
 	const user = {
 		id: Math.floor(Math.random() * 1000000),
 		firstName: firstName,

--- a/api/modules/users/userRouter.js
+++ b/api/modules/users/userRouter.js
@@ -1,0 +1,16 @@
+import { Router } from "express";
+
+import { handleCreateUser } from "./userService.js";
+const router = Router();
+
+router.post("/", (req, res) => {
+	const { firstName, lastName } = req.body;
+	if (!firstName || !lastName) {
+		return res.status(400).json({ error: "Missing firstName or lastName" });
+	}
+	const user = handleCreateUser({ firstName, lastName });
+
+	res.status(201).json(user);
+});
+
+export default router;

--- a/api/modules/users/userRouter.js
+++ b/api/modules/users/userRouter.js
@@ -1,14 +1,14 @@
 import { Router } from "express";
 
-import { handleCreateUser } from "./userService.js";
+import { handleRegisterUser } from "./userService.js";
 const router = Router();
 
-router.post("/", (req, res) => {
+router.post("/register_user", (req, res) => {
 	const { firstName, lastName } = req.body;
 	if (!firstName || !lastName) {
 		return res.status(400).json({ error: "Missing firstName or lastName" });
 	}
-	const user = handleCreateUser({ firstName, lastName });
+	const user = handleRegisterUser({ firstName, lastName });
 
 	res.status(201).json(user);
 });

--- a/api/modules/users/userService.js
+++ b/api/modules/users/userService.js
@@ -1,5 +1,5 @@
-import { createUser } from "./userRepository.js";
+import { registerUser } from "./userRepository.js";
 
-export function handleCreateUser({ firstName, lastName }) {
-	return createUser({ firstName, lastName });
+export function handleRegisterUser({ firstName, lastName }) {
+	return registerUser({ firstName, lastName });
 }

--- a/api/modules/users/userService.js
+++ b/api/modules/users/userService.js
@@ -1,0 +1,5 @@
+import { createUser } from "./userRepository.js";
+
+export function handleCreateUser({ firstName, lastName }) {
+	return createUser({ firstName, lastName });
+}

--- a/api/server.js
+++ b/api/server.js
@@ -1,10 +1,10 @@
-import { connectDb } from "./db.js";
+// import { connectDb } from "./db.js";
 import config from "./utils/config.js";
 import logger from "./utils/logger.js";
 
 const { port } = config.init();
 
-await connectDb();
+// await connectDb();
 
 const { default: app } = await import("./app.js");
 

--- a/linting/index.js
+++ b/linting/index.js
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import cyfConfig from "@codeyourfuture/eslint-config-standard";
 import vitestPlugin from "@vitest/eslint-plugin";
@@ -15,10 +17,12 @@ import reactRefreshPlugin from "eslint-plugin-react-refresh";
 import testingLibraryPlugin from "eslint-plugin-testing-library";
 import globals from "globals";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const {
 	engines: { node: nodeVersion },
 } = JSON.parse(
-	await readFile(resolve(import.meta.dirname, "..", "package.json"), "utf-8"),
+	await readFile(resolve(__dirname, "..", "package.json"), "utf-8"),
 );
 
 /** @type {import("eslint").Linter.Config[]} */


### PR DESCRIPTION
This PR introduces three new endpoints to manage desk bookings and user registration, implemented with fake data. The following endpoints have been implemented:

**Get All Desks:**

**Endpoint:** GET /api/v1/desks

**Response Example:**
[
  { "id": "abc", "name": "Desk 1" },
  { "id": "def", "name": "Desk 2" }
]

**Create a Booking** (Today's Date Implied):

**Endpoint:** POST /api/v1/bookings/create_booking

**Request Body Example:**
[
  {
    "user_id": 1,
    "desk_id": "abc"
  }
]
Fake Data Check: Verifies that a desk is not double-booked and ensures the user doesn't have an existing booking for the same day.

**Create a New User:**

**Endpoint:** POST /api/v1/auth/register_user

**Response Example:**
{
  "id": 1,
  "firstName": "Jane",
  "lastName": "Doe"
}

The "Create Booking" endpoint includes logic to check for existing bookings, preventing double-booking for the same day.

The "Create User" endpoint allows simple user registration with basic fields for now.



